### PR TITLE
Add option to use new heap_id_mask instead of old heap_mask

### DIFF
--- a/minui/Android.mk
+++ b/minui/Android.mk
@@ -29,6 +29,10 @@ else
   LOCAL_C_INCLUDES += $(commands_recovery_local_path)/minui/include
 endif
 
+ifeq ($(TW_NEW_ION_HEAP), true)
+  LOCAL_CFLAGS += -DNEW_ION_HEAP
+endif
+
 LOCAL_STATIC_LIBRARY := libpng
 LOCAL_WHOLE_STATIC_LIBRARIES := libpixelflinger_static
 LOCAL_MODULE := libminui

--- a/minui/graphics_overlay.c
+++ b/minui/graphics_overlay.c
@@ -145,7 +145,11 @@ int alloc_ion_mem(unsigned int size)
     ionAllocData.flags = 0;
     ionAllocData.len = size;
     ionAllocData.align = sysconf(_SC_PAGESIZE);
+#ifdef NEW_ION_HEAP
+    ionAllocData.heap_id_mask =
+#else
     ionAllocData.heap_mask =
+#endif
             ION_HEAP(ION_IOMMU_HEAP_ID) |
             ION_HEAP(ION_SYSTEM_CONTIG_HEAP_ID);
 

--- a/minuitwrp/Android.mk
+++ b/minuitwrp/Android.mk
@@ -26,6 +26,10 @@ else
   LOCAL_C_INCLUDES += $(commands_recovery_local_path)/minuitwrp/include
 endif
 
+ifeq ($(TW_NEW_ION_HEAP), true)
+  LOCAL_CFLAGS += -DNEW_ION_HEAP
+endif
+
 LOCAL_C_INCLUDES += \
     external/libpng \
     external/zlib \

--- a/minuitwrp/graphics_overlay.c
+++ b/minuitwrp/graphics_overlay.c
@@ -158,7 +158,11 @@ int alloc_ion_mem(unsigned int size)
     ionAllocData.flags = 0;
     ionAllocData.len = size;
     ionAllocData.align = sysconf(_SC_PAGESIZE);
+#ifdef NEW_ION_HEAP
+    ionAllocData.heap_id_mask =
+#else
     ionAllocData.heap_mask =
+#endif
             ION_HEAP(ION_IOMMU_HEAP_ID) |
             ION_HEAP(ION_SYSTEM_CONTIG_HEAP_ID);
 


### PR DESCRIPTION
Use TW_NEW_ION_HEAP := true to use it

Change-Id: I2ad105fa6d122b460ed4b5dc78563077b7904567